### PR TITLE
Add "GetLayoutAsync" command, "Hostname" getter, Optional HttpClient input

### DIFF
--- a/Nanoleaf.Client/Nanoleaf.Client/Models/Requests/Effects/SelectEternalModel.cs
+++ b/Nanoleaf.Client/Nanoleaf.Client/Models/Requests/Effects/SelectEternalModel.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using Newtonsoft.Json;
+
+namespace Nanoleaf.Client.Models.Requests.Effects {
+	[JsonObject(Title = "write")]
+	public class SelectEternalModel {
+		public SelectEternalModel(string controlVersion = "v2") {
+			write = new Write {ControlVersion = controlVersion, Command = "display", AnimationType = "extControl"};
+		}
+
+		public Write write;
+
+		[Serializable]
+		public class Write {
+			[JsonProperty("command")] 
+			public string Command;
+		
+			[JsonProperty("animType")] 
+			public string AnimationType;
+		
+			[JsonProperty("extControlVersion")] 
+			public string ControlVersion { get; set; }
+		}
+	}
+}

--- a/Nanoleaf.Client/Nanoleaf.Client/Models/Responses/Layout.cs
+++ b/Nanoleaf.Client/Nanoleaf.Client/Models/Responses/Layout.cs
@@ -1,54 +1,29 @@
 ﻿using System;
-using System.ComponentModel;
 using Newtonsoft.Json;
 
-namespace Nanoleaf.Client.Models.Responses {
+namespace Nanoleaf.Client.Models.Responses
+{
 	/// <summary>
 	/// Layout response returned from a layout request
 	/// </summary>
 	[Serializable]
-	public class Layout {
+	public class Layout
+	{
 		/// <summary>
 		/// Number of panels
 		/// </summary>
-		[JsonProperty] public int NumPanels { get; set; }
+		[JsonProperty]
+		public int NumPanels { get; set; }
 		/// <summary>
 		/// Side of each length
 		/// </summary>
-		[JsonProperty] public int SideLength { get; set; } = 1;
+		[JsonProperty]
+		public int SideLength { get; set; } = 1;
 		/// <summary>
 		/// Array of position data
 		/// </summary>
-		[JsonProperty] public PanelLayout[] PositionData { get; set; } = Array.Empty<PanelLayout>();
+		[JsonProperty]
+		public PanelLayout[] PositionData { get; set; } = Array.Empty<PanelLayout>();
 
-	}
-
-	/// <summary>
-	/// Layout info on a specific panel
-	/// </summary>
-	[Serializable]
-	public class PanelLayout {
-		/// <summary>
-		/// Unique panel ID
-		/// </summary>
-		[JsonProperty] public int PanelId { get; set; }
-		/// <summary>
-		/// X coordinate
-		/// </summary>
-		[JsonProperty] public int X { get; set; }
-
-		/// <summary>
-		/// Y coordinate
-		/// </summary>
-		[DefaultValue(10)]
-		[JsonProperty(DefaultValueHandling = DefaultValueHandling.Populate)]
-		public int Y { get; set; } = 10;
-
-		[JsonProperty] public int O { get; set; }
-		
-		/// <summary>
-		/// Shape type, should probably be an enum
-		/// </summary>
-		[JsonProperty] public int ShapeType { get; set; }
 	}
 }

--- a/Nanoleaf.Client/Nanoleaf.Client/Models/Responses/Layout.cs
+++ b/Nanoleaf.Client/Nanoleaf.Client/Models/Responses/Layout.cs
@@ -1,0 +1,54 @@
+﻿using System;
+using System.ComponentModel;
+using Newtonsoft.Json;
+
+namespace Nanoleaf.Client.Models.Responses {
+	/// <summary>
+	/// Layout response returned from a layout request
+	/// </summary>
+	[Serializable]
+	public class Layout {
+		/// <summary>
+		/// Number of panels
+		/// </summary>
+		[JsonProperty] public int NumPanels { get; set; }
+		/// <summary>
+		/// Side of each length
+		/// </summary>
+		[JsonProperty] public int SideLength { get; set; } = 1;
+		/// <summary>
+		/// Array of position data
+		/// </summary>
+		[JsonProperty] public PanelLayout[] PositionData { get; set; } = Array.Empty<PanelLayout>();
+
+	}
+
+	/// <summary>
+	/// Layout info on a specific panel
+	/// </summary>
+	[Serializable]
+	public class PanelLayout {
+		/// <summary>
+		/// Unique panel ID
+		/// </summary>
+		[JsonProperty] public int PanelId { get; set; }
+		/// <summary>
+		/// X coordinate
+		/// </summary>
+		[JsonProperty] public int X { get; set; }
+
+		/// <summary>
+		/// Y coordinate
+		/// </summary>
+		[DefaultValue(10)]
+		[JsonProperty(DefaultValueHandling = DefaultValueHandling.Populate)]
+		public int Y { get; set; } = 10;
+
+		[JsonProperty] public int O { get; set; }
+		
+		/// <summary>
+		/// Shape type, should probably be an enum
+		/// </summary>
+		[JsonProperty] public int ShapeType { get; set; }
+	}
+}

--- a/Nanoleaf.Client/Nanoleaf.Client/Models/Responses/PanelLayout.cs
+++ b/Nanoleaf.Client/Nanoleaf.Client/Models/Responses/PanelLayout.cs
@@ -1,0 +1,43 @@
+﻿using System;
+using System.ComponentModel;
+using Newtonsoft.Json;
+
+namespace Nanoleaf.Client.Models.Responses
+{
+	/// <summary>
+	/// Layout info on a specific panel
+	/// </summary>
+	[Serializable]
+	public class PanelLayout
+	{
+		/// <summary>
+		/// Unique panel ID
+		/// </summary>
+		[JsonProperty]
+		public int PanelId { get; set; }
+		/// <summary>
+		/// X coordinate
+		/// </summary>
+		[JsonProperty]
+		public int X { get; set; }
+
+		/// <summary>
+		/// Y coordinate
+		/// </summary>
+		[DefaultValue(10)]
+		[JsonProperty(DefaultValueHandling = DefaultValueHandling.Populate)]
+		public int Y { get; set; } = 10;
+
+		/// <summary>
+		/// Orientation
+		/// </summary>
+		[JsonProperty]
+		public int O { get; set; }
+		
+		/// <summary>
+		/// Shape type, should probably be an enum
+		/// </summary>
+		[JsonProperty]
+		public int ShapeType { get; set; }
+	}
+}

--- a/Nanoleaf.Client/Nanoleaf.Client/Nanoleaf.Client.csproj
+++ b/Nanoleaf.Client/Nanoleaf.Client/Nanoleaf.Client.csproj
@@ -19,7 +19,7 @@
 	<GenerateDocumentationFile>true</GenerateDocumentationFile>
 	<PackageIconUrl>https://github.com/BullFrog13/Nanoleaf-Client/blob/master/nano1.png?raw=true</PackageIconUrl>
 	<Company>BullFrog13</Company>
-	<PackageVersion>1.1.7.2</PackageVersion>
+	<PackageVersion>1.1.7.3</PackageVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Nanoleaf.Client/Nanoleaf.Client/Nanoleaf.Client.csproj
+++ b/Nanoleaf.Client/Nanoleaf.Client/Nanoleaf.Client.csproj
@@ -19,6 +19,7 @@
 	<GenerateDocumentationFile>true</GenerateDocumentationFile>
 	<PackageIconUrl>https://github.com/BullFrog13/Nanoleaf-Client/blob/master/nano1.png?raw=true</PackageIconUrl>
 	<Company>BullFrog13</Company>
+	<PackageVersion>1.1.7.2</PackageVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Nanoleaf.Client/Nanoleaf.Client/NanoleafClient.cs
+++ b/Nanoleaf.Client/Nanoleaf.Client/NanoleafClient.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Net.Http;
 using System.Threading.Tasks;
 using Nanoleaf.Client.Colors;
 using Nanoleaf.Client.Helpers;
@@ -53,6 +54,10 @@ namespace Nanoleaf.Client
 
         #region User
 
+        /// <summary>
+        /// Attempt to create a new user token object.
+        /// </summary>
+        /// <returns>New user token</returns>
         public async Task<UserToken> CreateTokenAsync()
         {
             var response = await _nanoleafHttpClient.AddUserRequestAsync();
@@ -79,6 +84,17 @@ namespace Nanoleaf.Client
             var powerStatus = JsonConvert.DeserializeObject<PowerStatus>(response);
 
             return powerStatus.Value;
+        }
+
+        /// <summary>
+        /// Retrieves the current panel layout.
+        /// Requires authorization.
+        /// </summary>
+        /// <returns></returns>
+        public async Task<Layout> GetLayoutAsync() {
+            var response = await _nanoleafHttpClient.SendGetRequest("panelLayout/layout");
+            var layout = JsonConvert.DeserializeObject<Layout>(response);
+            return layout;
         }
 
         /// <inheritdoc/>

--- a/Nanoleaf.Client/Nanoleaf.Client/NanoleafClient.cs
+++ b/Nanoleaf.Client/Nanoleaf.Client/NanoleafClient.cs
@@ -51,6 +51,18 @@ namespace Nanoleaf.Client
 
             return info;
         }
+        
+        /// <summary>
+        /// Retrieves the current panel layout.
+        /// Requires authorization.
+        /// </summary>
+        /// <returns></returns>
+        public async Task<Layout> GetLayoutAsync() {
+            var response = await _nanoleafHttpClient.SendGetRequest("panelLayout/layout");
+            var layout = JsonConvert.DeserializeObject<Layout>(response);
+            return layout;
+        }
+
 
         #region User
 
@@ -86,17 +98,7 @@ namespace Nanoleaf.Client
             return powerStatus.Value;
         }
 
-        /// <summary>
-        /// Retrieves the current panel layout.
-        /// Requires authorization.
-        /// </summary>
-        /// <returns></returns>
-        public async Task<Layout> GetLayoutAsync() {
-            var response = await _nanoleafHttpClient.SendGetRequest("panelLayout/layout");
-            var layout = JsonConvert.DeserializeObject<Layout>(response);
-            return layout;
-        }
-
+        
         /// <inheritdoc/>
         public async Task TurnOnAsync()
         {
@@ -413,6 +415,17 @@ namespace Nanoleaf.Client
 
             await _nanoleafHttpClient.SendPutRequest(json, "effects/");
         }
+        
+        /// <inheritdoc/>
+        public async Task StartExternalAsync(string version="v2")
+        {
+            var request = new SelectEternalModel(version);
+            var json = JsonConvert.SerializeObject(request);
+
+            await _nanoleafHttpClient.SendPutRequest(json, "effects/");
+        }
+        
+        
 
         #endregion
 

--- a/Nanoleaf.Client/Nanoleaf.Client/NanoleafClient.cs
+++ b/Nanoleaf.Client/Nanoleaf.Client/NanoleafClient.cs
@@ -19,17 +19,23 @@ namespace Nanoleaf.Client
     {
         private bool _isDisposed;
         private readonly NanoleafHttpClient _nanoleafHttpClient;
+        /// <summary>
+        /// Allow us to retrieve the device hostname for later
+        /// </summary>
+        public string HostName { get; }
 
-        public NanoleafClient(string host)
+        /// <summary>
+        /// Create a new nanoleaf client
+        /// </summary>
+        /// <param name="host">Hostname or IP address of nanoleaf device</param>
+        /// <param name="userToken">(Optional) User token to use if authorized</param>
+        /// <param name="client">(Optional) Used to pass a shared HttpClient</param>
+        public NanoleafClient(string host, string userToken = "", HttpClient client = null)
         {
-            _nanoleafHttpClient = new NanoleafHttpClient(host);
+            _nanoleafHttpClient = new NanoleafHttpClient(host, userToken, client);
+            HostName = host;
         }
-
-        public NanoleafClient(string host, string userToken)
-        {
-            _nanoleafHttpClient = new NanoleafHttpClient(host, userToken);
-        }
-
+        
         /// <inheritdoc/>
         public void Authorize(string token)
         {

--- a/Nanoleaf.Client/Nanoleaf.Client/NanoleafStreamingClient.cs
+++ b/Nanoleaf.Client/Nanoleaf.Client/NanoleafStreamingClient.cs
@@ -1,0 +1,176 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Drawing;
+using System.Globalization;
+using System.Linq;
+using System.Net;
+using System.Net.Sockets;
+using System.Threading.Tasks;
+using ISocketLite.PCL.Exceptions;
+using SocketException = System.Net.Sockets.SocketException;
+
+namespace Nanoleaf.Client {
+	public class NanoleafStreamingClient : IDisposable {
+		private readonly int _streamMode;
+		private readonly IPEndPoint _ipEndPoint;
+		private readonly UdpClient _sender;
+		private bool _disposeSender;
+
+		/// <summary>
+		/// Create a new nanoleaf streaming client
+		/// </summary>
+		/// <param name="target">The IP Address or hostname of the nanoleaf device.</param>
+		/// <param name="streamMode">(Optional) Streaming mode supported by the device. See the nanoleaf documentation for more info.</param>
+		/// <param name="sender">(Optional) If specified, use a shared UdpClient. Be sure to disable blocking and
+		/// set the socket options to ReuseAddress, or you will encounter issues.</param>
+		public NanoleafStreamingClient(string target, int streamMode = 2, UdpClient sender = null) {
+			_ipEndPoint = Parse(target, 60222);
+
+			if (sender != null) {
+				_sender = sender;
+			} else {
+				_disposeSender = true;
+				_sender = new UdpClient();
+				_sender.Client.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.ReuseAddress, true);
+				_sender.Client.Blocking = false;
+				_sender.DontFragment = true;
+			}
+			_streamMode = streamMode;
+		}
+		
+		
+		/// <summary>
+		/// Send a UDP packet with updated color data
+		/// </summary>
+		/// <param name="colors">A dictionary of int, color; where int is the Panel ID,
+		/// and color is a System.Drawing.Color to set. Use <see cref="M:NanoleafClient.GetLayoutAsync"/> to get layout info.</param>
+		/// <param name="fadeTime"></param>
+		public async Task SetColorAsync(Dictionary<int, Color> colors, int fadeTime = 0) {
+			var byteString = new List<byte>();
+			if (_streamMode == 2) {
+				byteString.AddRange(PadInt(colors.Count));
+			} else {
+				byteString.Add(IntByte(colors.Count));
+			}
+			foreach (var pd in colors) {
+				var id = pd.Key;
+				if (_streamMode == 2) {
+					byteString.AddRange(PadInt(id));
+				} else {
+					byteString.Add(IntByte(id));
+				}
+
+				var color = pd.Value;
+				
+				// Add rgb values
+				byteString.Add(IntByte(color.R));
+				byteString.Add(IntByte(color.G));
+				byteString.Add(IntByte(color.B));
+				// White value
+				byteString.AddRange(PadInt(0, 1));
+				// Pad duration time
+				byteString.AddRange(_streamMode == 2 ? PadInt(fadeTime) : PadInt(fadeTime, 1));
+			}
+
+			await SendUdpUnicastAsync(byteString.ToArray());
+		}
+		
+		private static byte[] PadInt(int toPad, int take = 2) {
+			var intBytes = BitConverter.GetBytes(toPad);
+			Array.Reverse(intBytes);
+			intBytes = intBytes.Reverse().Take(take).Reverse().ToArray();
+			return intBytes;
+		}
+		
+		private static byte IntByte(int toByte, string format = "X2") {
+			var b = Convert.ToByte(toByte.ToString(format, CultureInfo.InvariantCulture), 16);
+			return b;
+		}
+		
+		private async Task SendUdpUnicastAsync(byte[] data) {
+			if (_ipEndPoint != null) {
+				await _sender.SendAsync(data, data.Length, _ipEndPoint);
+			} else {
+				throw new Exception("Error, no endpoint");
+			}
+		}
+		
+		private static IPEndPoint Parse(string endpoint, int portIn) {
+            if (string.IsNullOrEmpty(endpoint)
+                || endpoint.Trim().Length == 0) {
+                throw new ArgumentException("Endpoint descriptor may not be empty.");
+            }
+
+            if (portIn != -1 &&
+                (portIn < IPEndPoint.MinPort
+                 || portIn > IPEndPoint.MaxPort)) {
+                throw new ArgumentException(string.Format("Invalid default port '{0}'", portIn));
+            }
+
+            string[] values = endpoint.Split(new[] {':'});
+            IPAddress ipaddy;
+            int port;
+
+            //check if we have an IPv6 or ports
+            if (values.Length <= 2) // ipv4 or hostname
+            {
+                if (values.Length == 1)
+                    //no port is specified, default
+                    port = portIn;
+                else
+                    port = GetPort(values[1]);
+
+                //try to use the address as IPv4, otherwise get hostname
+                if (!IPAddress.TryParse(values[0], out ipaddy))
+                    ipaddy = GetIpFromHost(values[0]);
+                if (ipaddy == null) return null;
+            } else if (values.Length > 2) //ipv6
+            {
+                //could [a:b:c]:d
+                if (values[0].StartsWith("[") && values[values.Length - 2].EndsWith("]")) {
+                    string ipaddressstring = string.Join(":", values.Take(values.Length - 1).ToArray());
+                    ipaddy = IPAddress.Parse(ipaddressstring);
+                    port = GetPort(values[values.Length - 1]);
+                } else //[a:b:c] or a:b:c
+                {
+                    ipaddy = IPAddress.Parse(endpoint);
+                    port = portIn;
+                }
+            } else {
+                throw new FormatException(string.Format("Invalid endpoint ipaddress '{0}'", endpoint));
+            }
+
+            if (port == -1)
+                throw new ArgumentException(string.Format("No port specified: '{0}'", endpoint));
+
+            return new IPEndPoint(ipaddy, port);
+        }
+		
+		private static int GetPort(string p) {
+			int port;
+
+			if (!int.TryParse(p, out port)
+			    || port < IPEndPoint.MinPort
+			    || port > IPEndPoint.MaxPort) {
+				throw new FormatException($@"Invalid end point port '{p}'");
+			}
+
+			return port;
+		}
+
+		private static IPAddress GetIpFromHost(string p) {
+			if (string.IsNullOrEmpty(p)) return null;
+			var hosts = Dns.GetHostAddresses(p);
+
+			if (hosts == null || hosts.Length == 0)
+				throw new ArgumentException(string.Format("Host not found: {0}", p));
+
+			return hosts[0];
+		}
+
+
+		public void Dispose() {
+			if (_disposeSender) _sender?.Dispose();
+		}
+	}
+}

--- a/Nanoleaf.Client/Nanoleaf.Client/NanoleafStreamingClient.cs
+++ b/Nanoleaf.Client/Nanoleaf.Client/NanoleafStreamingClient.cs
@@ -6,8 +6,6 @@ using System.Linq;
 using System.Net;
 using System.Net.Sockets;
 using System.Threading.Tasks;
-using ISocketLite.PCL.Exceptions;
-using SocketException = System.Net.Sockets.SocketException;
 
 namespace Nanoleaf.Client {
 	public class NanoleafStreamingClient : IDisposable {

--- a/Nanoleaf.Client/Nanoleaf.Client/NanoleafStreamingClient.cs
+++ b/Nanoleaf.Client/Nanoleaf.Client/NanoleafStreamingClient.cs
@@ -7,12 +7,17 @@ using System.Net;
 using System.Net.Sockets;
 using System.Threading.Tasks;
 
-namespace Nanoleaf.Client {
-	public class NanoleafStreamingClient : IDisposable {
+namespace Nanoleaf.Client 
+{
+	/// <summary>
+	/// Streaming client used for sending UDP color data to Nanoleaf Devices
+	/// </summary>
+	public class NanoleafStreamingClient : IDisposable
+	{
 		private readonly int _streamMode;
 		private readonly IPEndPoint _ipEndPoint;
 		private readonly UdpClient _sender;
-		private bool _disposeSender;
+		private readonly bool _disposeSender;
 
 		/// <summary>
 		/// Create a new nanoleaf streaming client
@@ -21,7 +26,8 @@ namespace Nanoleaf.Client {
 		/// <param name="streamMode">(Optional) Streaming mode supported by the device. See the nanoleaf documentation for more info.</param>
 		/// <param name="sender">(Optional) If specified, use a shared UdpClient. Be sure to disable blocking and
 		/// set the socket options to ReuseAddress, or you will encounter issues.</param>
-		public NanoleafStreamingClient(string target, int streamMode = 2, UdpClient sender = null) {
+		public NanoleafStreamingClient(string target, int streamMode = 2, UdpClient sender = null)
+		{
 			_ipEndPoint = Parse(target, 60222);
 
 			if (sender != null) {
@@ -43,7 +49,8 @@ namespace Nanoleaf.Client {
 		/// <param name="colors">A dictionary of int, color; where int is the Panel ID,
 		/// and color is a System.Drawing.Color to set. Use <see cref="M:NanoleafClient.GetLayoutAsync"/> to get layout info.</param>
 		/// <param name="fadeTime"></param>
-		public async Task SetColorAsync(Dictionary<int, Color> colors, int fadeTime = 0) {
+		public async Task SetColorAsync(Dictionary<int, Color> colors, int fadeTime = 0)
+		{
 			var byteString = new List<byte>();
 			if (_streamMode == 2) {
 				byteString.AddRange(PadInt(colors.Count));
@@ -73,19 +80,22 @@ namespace Nanoleaf.Client {
 			await SendUdpUnicastAsync(byteString.ToArray());
 		}
 		
-		private static byte[] PadInt(int toPad, int take = 2) {
+		private static byte[] PadInt(int toPad, int take = 2)
+		{
 			var intBytes = BitConverter.GetBytes(toPad);
 			Array.Reverse(intBytes);
 			intBytes = intBytes.Reverse().Take(take).Reverse().ToArray();
 			return intBytes;
 		}
 		
-		private static byte IntByte(int toByte, string format = "X2") {
+		private static byte IntByte(int toByte, string format = "X2")
+		{
 			var b = Convert.ToByte(toByte.ToString(format, CultureInfo.InvariantCulture), 16);
 			return b;
 		}
 		
-		private async Task SendUdpUnicastAsync(byte[] data) {
+		private async Task SendUdpUnicastAsync(byte[] data)
+		{
 			if (_ipEndPoint != null) {
 				await _sender.SendAsync(data, data.Length, _ipEndPoint);
 			} else {
@@ -93,7 +103,8 @@ namespace Nanoleaf.Client {
 			}
 		}
 		
-		private static IPEndPoint Parse(string endpoint, int portIn) {
+		private static IPEndPoint Parse(string endpoint, int portIn) 
+		{
             if (string.IsNullOrEmpty(endpoint)
                 || endpoint.Trim().Length == 0) {
                 throw new ArgumentException("Endpoint descriptor may not be empty.");
@@ -144,7 +155,8 @@ namespace Nanoleaf.Client {
             return new IPEndPoint(ipaddy, port);
         }
 		
-		private static int GetPort(string p) {
+		private static int GetPort(string p) 
+		{
 			int port;
 
 			if (!int.TryParse(p, out port)
@@ -156,7 +168,8 @@ namespace Nanoleaf.Client {
 			return port;
 		}
 
-		private static IPAddress GetIpFromHost(string p) {
+		private static IPAddress GetIpFromHost(string p) 
+		{
 			if (string.IsNullOrEmpty(p)) return null;
 			var hosts = Dns.GetHostAddresses(p);
 
@@ -167,7 +180,8 @@ namespace Nanoleaf.Client {
 		}
 
 
-		public void Dispose() {
+		public void Dispose() 
+		{
 			if (_disposeSender) _sender?.Dispose();
 		}
 	}

--- a/Nanoleaf.Client/Nanoleaf.Test/Program.cs
+++ b/Nanoleaf.Client/Nanoleaf.Test/Program.cs
@@ -37,7 +37,7 @@ namespace Nanoleaf.Test
             {
                 client.Authorize("aDmIB12fYRH7WAOKrzt1ucEuaJWzltT3");
                 var res = client.GetInfoAsync().Result;
-                Console.WriteLine("Test: " + res.State.Switch.Power);
+                Console.WriteLine($"Test for {client.HostName}: " + res.State.Switch.Power);
             }
 
             Console.ReadKey();

--- a/README.md
+++ b/README.md
@@ -50,6 +50,18 @@ Provided that you know your local device IP and already have a user token.
 var client = new NanoleafClient("<local_device_ip>", "<USER_TOKEN>");
 ```
 
+Optionally, you can pass an existing HttpClient to NanoLeafClient if you wish to re-use it.
+```c#
+var httpClient = new HttpClient();
+var client = new NanoleafClient("<local_device_ip>", "<USER_TOKEN>", httpClient);
+```
+
+You can also retrieve the hostname from the Nanoleaf Client.
+```c#
+var client = new NanoleafClient("<local_device_ip>");
+var hostname = client.HostName;
+```
+
 Disposable
 ```c#
 using(var client = new NanoleafClient("<local_device_ip>", "<USER_TOKEN>")
@@ -109,10 +121,103 @@ await nanoleaf.SetBrightnessAsync(targetBrightness: 100, time: 1000);
 await nanoleaf.RaiseBrightnessAsync(20);
 ```
 
-### Lower Brghtness
+### Lower Brightness
 
 ```c#
 await nanoleaf.LowerBrightnessAsync(5);
 ```
+
+### Get Layout
+
+```c#
+await nanoleaf.GetLayoutAsync();
+```
+
+### Start Streaming
+
+```c#
+await nanoleaf.StartExternalAsync();
+```
+
+## Create a Streaming Client
+
+Before sending data to your nanoleaf, you must first have authorized to your device.
+Once authorized, you should call "nanoleaf.StartExternalAsync()";
+
+```c#
+var client = new NanoleafClient("<local_device_ip>", "<USER_TOKEN>");
+await client.StartExternalAsync();
+
+var nanoStream = new NanoleafStreamingClient("<local_device_ip_or_hostname>");
+```
+
+The structure of the data sent to the device depends on the API version. Most devices 
+should use the V2 structure, which is the default setting. If you wish to use V1, specify it in the 
+streaming client's constructor.
+
+```c#
+var nanoStream = new NanoleafStreamingClient("<local_device_ip_or_hostname>", 1); // Specify version 1
+```
+
+Additionally, if you wish to use an existing UDP client, you can do so in the constructor.
+
+```c#
+var UdpClient = new UdpClient {Ttl = 5};
+UdpClient.Client.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.ReuseAddress, true);
+UdpClient.Client.Blocking = false;
+UdpClient.DontFragment = true;
+var nanoStream = new NanoleafStreamingClient("<local_device_ip_or_hostname>", 2, UdpClient);
+```
+
+### Sending Color Data
+
+To send color data after initializing a Streaming Client, you first need to know the id's of
+the panels to address. 
+
+Once you have the IDs, create a Dictionary<int, System.Drawing.Color>. Assign the panel ID to the
+dictionary's key, and the desired color to the corresponding value.
+
+Pass this dictionary to the nanostreaming client with an optional fade time, and repeat as necessary.
+
+```c#
+// Create client
+var client = new NanoleafClient("<local_device_ip>", "<USER_TOKEN>");
+
+// Retrieve our layout
+var layout = client.GetLayoutAsync();
+// Create a dictionary to pass to the stream
+var allRed = new Dictionary<int,Color>();
+var allBlack = new Dictionary<int,Color>();
+// Create colors
+var redColor = Color.FromArgb(255,0,0);
+var blackColor = Color.FromArgb(0,0,0);
+
+// Create stream
+var nanoStream = new NanoleafStreamingClient("<local_device_ip_or_hostname>", 1); // Specify version 1
+
+// Fill red dict 
+foreach (var position in layout.PositionData) {
+    allRed[position.PanelId] = redColor;
+}
+
+// Fill black dict
+foreach (var position in layout.PositionData) {
+    allBlack[position.PanelId] = blackColor;
+}
+
+// Start streaming
+await client.StartExternalAsync();
+
+// Set all panels to red with no delay
+await nanoStream.SetColorAsync(allRed);
+await Task.Delay(1000);
+
+// Set all panels to black with 500ms fade time
+await nanoStream.SetColorAsync(allBlack, 500);
+
+
+
+```
+
 
 [1]: https://forum.nanoleaf.me/docs/openapi


### PR DESCRIPTION
Add option to retrieve panel layout...as I use that one a lot.
Add getter for Hostname, so it can be read from the client at a later time if desired.
Add option to pass an existing HttpClient to LifxClient constructor. I did this because in my app, I have many devices which use a HttpClient, and found it is more efficient to just cache one and use it everywhere, versus creating a new one for each device.
I also removed the two-param constructor for LifxClient, and just created one with three values that have optional fallbacks - meaning nothing should change at all user-side in terms of creating a new client.